### PR TITLE
feat: Add `Builder::permissions()` method.

### DIFF
--- a/src/file/imp/other.rs
+++ b/src/file/imp/other.rs
@@ -9,7 +9,11 @@ fn not_supported<T>() -> io::Result<T> {
     ))
 }
 
-pub fn create_named(_path: &Path, _open_options: &mut OpenOptions) -> io::Result<File> {
+pub fn create_named(
+    _path: &Path,
+    _open_options: &mut OpenOptions,
+    _permissions: Option<&std::fs::Permissions>,
+) -> io::Result<File> {
     not_supported()
 }
 

--- a/src/file/imp/unix.rs
+++ b/src/file/imp/unix.rs
@@ -4,7 +4,7 @@ use std::fs::{self, File, OpenOptions};
 use std::io;
 cfg_if::cfg_if! {
     if #[cfg(not(target_os = "wasi"))] {
-        use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
+        use std::os::unix::fs::MetadataExt;
     } else {
         #[cfg(feature = "nightly")]
         use std::os::wasi::fs::MetadataExt;
@@ -20,14 +20,11 @@ use {
 };
 
 pub fn create_named(path: &Path, open_options: &mut OpenOptions) -> io::Result<File> {
-    open_options.read(true).write(true).create_new(true);
-
-    #[cfg(not(target_os = "wasi"))]
-    {
-        open_options.mode(0o600);
-    }
-
-    open_options.open(path)
+    open_options
+        .read(true)
+        .write(true)
+        .create_new(true)
+        .open(path)
 }
 
 fn create_unlinked(path: &Path) -> io::Result<File> {
@@ -50,6 +47,7 @@ fn create_unlinked(path: &Path) -> io::Result<File> {
 #[cfg(target_os = "linux")]
 pub fn create(dir: &Path) -> io::Result<File> {
     use rustix::{fs::OFlags, io::Errno};
+    use std::os::unix::fs::OpenOptionsExt;
     OpenOptions::new()
         .read(true)
         .write(true)

--- a/src/file/imp/windows.rs
+++ b/src/file/imp/windows.rs
@@ -19,7 +19,11 @@ fn to_utf16(s: &Path) -> Vec<u16> {
     s.as_os_str().encode_wide().chain(iter::once(0)).collect()
 }
 
-pub fn create_named(path: &Path, open_options: &mut OpenOptions) -> io::Result<File> {
+pub fn create_named(
+    path: &Path,
+    open_options: &mut OpenOptions,
+    _permissions: Option<&std::fs::Permissions>,
+) -> io::Result<File> {
     open_options
         .create_new(true)
         .read(true)

--- a/src/file/mod.rs
+++ b/src/file/mod.rs
@@ -1107,13 +1107,14 @@ impl<F: AsRawHandle> AsRawHandle for NamedTempFile<F> {
 pub(crate) fn create_named(
     mut path: PathBuf,
     open_options: &mut OpenOptions,
+    permissions: Option<&std::fs::Permissions>,
 ) -> io::Result<NamedTempFile> {
     // Make the path absolute. Otherwise, changing directories could cause us to
     // delete the wrong file.
     if !path.is_absolute() {
         path = env::current_dir()?.join(path)
     }
-    imp::create_named(&path, open_options)
+    imp::create_named(&path, open_options, permissions)
         .with_err_path(|| path.clone())
         .map(|file| NamedTempFile {
             path: TempPath {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -197,6 +197,7 @@ pub struct Builder<'a, 'b> {
     prefix: &'a OsStr,
     suffix: &'b OsStr,
     append: bool,
+    permissions: Option<std::fs::Permissions>,
 }
 
 impl<'a, 'b> Default for Builder<'a, 'b> {
@@ -206,6 +207,7 @@ impl<'a, 'b> Default for Builder<'a, 'b> {
             prefix: OsStr::new(".tmp"),
             suffix: OsStr::new(""),
             append: false,
+            permissions: None,
         }
     }
 }
@@ -396,6 +398,63 @@ impl<'a, 'b> Builder<'a, 'b> {
     /// ```
     pub fn append(&mut self, append: bool) -> &mut Self {
         self.append = append;
+        self
+    }
+
+    /// The permissions to create the tempfile with.
+    /// This allows to them differ from the default mode of `0o600` on Unix.
+    ///
+    /// # Security
+    ///
+    /// By default, the permissions of tempfiles on unix are set for it to be
+    /// readable and writable by the owner only, yielding the greatest amount
+    /// of security.
+    /// As this method allows to widen the permissions, security would be
+    /// reduced in such cases.
+    ///
+    /// # Platform Notes
+    /// ## Unix
+    ///
+    /// The actual permission bits set on the tempfile will be affected by the
+    /// `umask` applied by the underlying `open` syscall.
+    ///
+    /// ## Windows and others
+    ///
+    /// This setting is ignored.
+    ///
+    /// # Limitations
+    ///
+    /// Permissions for directories aren't currently set even though it would
+    /// be possible on Unix systems.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use std::io;
+    /// # fn main() {
+    /// #     if let Err(_) = run() {
+    /// #         ::std::process::exit(1);
+    /// #     }
+    /// # }
+    /// # fn run() -> Result<(), io::Error> {
+    /// # use tempfile::Builder;
+    /// #[cfg(unix)]
+    /// {
+    ///     use std::os::unix::fs::PermissionsExt;
+    ///     let all_read_write = std::fs::Permissions::from_mode(0o666);
+    ///     let tempfile = Builder::new().permissions(all_read_write).tempfile()?;
+    ///     let actual_permissions = tempfile.path().metadata()?.permissions();
+    ///     assert_ne!(
+    ///         actual_permissions.mode() & !0o170000,
+    ///         0o600,
+    ///         "we get broader permissions than the default despite umask"
+    ///     );
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn permissions(&mut self, permissions: std::fs::Permissions) -> &mut Self {
+        self.permissions = Some(permissions);
         self
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -532,7 +532,16 @@ impl<'a, 'b> Builder<'a, 'b> {
             self.prefix,
             self.suffix,
             self.random_len,
-            |path| file::create_named(path, OpenOptions::new().append(self.append)),
+            |path| {
+                let mut open_options = OpenOptions::new();
+                open_options.append(self.append);
+                #[cfg(all(unix, not(target_os = "wasi")))]
+                {
+                    use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+                    open_options.mode(self.permissions.as_ref().map(|p| p.mode()).unwrap_or(0o600));
+                }
+                file::create_named(path, &mut open_options)
+            },
         )
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -533,14 +533,11 @@ impl<'a, 'b> Builder<'a, 'b> {
             self.suffix,
             self.random_len,
             |path| {
-                let mut open_options = OpenOptions::new();
-                open_options.append(self.append);
-                #[cfg(all(unix, not(target_os = "wasi")))]
-                {
-                    use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
-                    open_options.mode(self.permissions.as_ref().map(|p| p.mode()).unwrap_or(0o600));
-                }
-                file::create_named(path, &mut open_options)
+                file::create_named(
+                    path,
+                    OpenOptions::new().append(self.append),
+                    self.permissions.as_ref(),
+                )
             },
         )
     }


### PR DESCRIPTION
With it it's possible to change the default mode of tempfiles on unix systems.